### PR TITLE
[KW-187] feat: 건물 조회 기능 구현

### DIFF
--- a/src/main/java/com/doubleo/hospitalservice/HospitalServiceApplication.java
+++ b/src/main/java/com/doubleo/hospitalservice/HospitalServiceApplication.java
@@ -2,8 +2,10 @@ package com.doubleo.hospitalservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class HospitalServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/controller/BuildingController.java
@@ -1,0 +1,28 @@
+package com.doubleo.hospitalservice.domain.building.controller;
+
+import com.doubleo.hospitalservice.domain.building.dto.response.BuildingInfoResponse;
+import com.doubleo.hospitalservice.domain.building.service.BuildingSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/buildings")
+@RequiredArgsConstructor
+public class BuildingController {
+
+    private final BuildingSearchService buildingSearchService;
+
+    @GetMapping
+    @Operation(
+            summary = "Get Buildings by Hospital ID",
+            description = "병원 ID를 기준으로 건물 리스트를 조회하는 API")
+    public ResponseEntity<List<BuildingInfoResponse>> buildingsGetByHospitalId(
+            @RequestParam Long hospitalId) {
+        List<BuildingInfoResponse> buildings =
+                buildingSearchService.getBuildingsByHospitalId(hospitalId);
+        return ResponseEntity.ok(buildings);
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/controller/BuildingController.java
@@ -5,7 +5,6 @@ import com.doubleo.hospitalservice.domain.building.service.BuildingSearchService
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,10 +18,7 @@ public class BuildingController {
     @Operation(
             summary = "Get Buildings by Hospital ID",
             description = "병원 ID를 기준으로 건물 리스트를 조회하는 API")
-    public ResponseEntity<List<BuildingInfoResponse>> buildingsGetByHospitalId(
-            @RequestParam Long hospitalId) {
-        List<BuildingInfoResponse> buildings =
-                buildingSearchService.getBuildingsByHospitalId(hospitalId);
-        return ResponseEntity.ok(buildings);
+    public List<BuildingInfoResponse> buildingsGetByHospitalId(@RequestParam Long hospitalId) {
+        return buildingSearchService.getBuildingsByHospitalId(hospitalId);
     }
 }

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/dto/response/BuildingInfoResponse.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/dto/response/BuildingInfoResponse.java
@@ -1,0 +1,14 @@
+package com.doubleo.hospitalservice.domain.building.dto.response;
+
+import com.doubleo.hospitalservice.domain.building.domain.Building;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BuildingInfoResponse(
+        @Schema(description = "건물 아이디", example = "1") Long buildingId,
+        @Schema(description = "건물 이름", example = "서울아산병원 A동") String buildingName,
+        @Schema(description = "건물 코드", example = "A") String buildingCode) {
+    public static BuildingInfoResponse from(Building building) {
+        return new BuildingInfoResponse(
+                building.getBuildingId(), building.getBuildingName(), building.getBuildingCode());
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/repository/BuildingRepository.java
@@ -1,0 +1,11 @@
+package com.doubleo.hospitalservice.domain.building.repository;
+
+import com.doubleo.hospitalservice.domain.building.domain.Building;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+    List<Building> findAllByTenantId(Long tenantId);
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingSearchService.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingSearchService.java
@@ -1,0 +1,28 @@
+package com.doubleo.hospitalservice.domain.building.service;
+
+import com.doubleo.hospitalservice.domain.building.dto.response.BuildingInfoResponse;
+import com.doubleo.hospitalservice.domain.hospital.service.HospitalInternalService;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+// 병원 야이디로 건물을 조회하는 서비스
+// 병원 ID → 테넌트 ID 조회 → 해당 테넌트에 속한 건물 목록 반환
+// 단일 도메인 로직이 아닌 Hospital + Building 도메인이 사용되므로 별도의 SearchService로 분리함
+public class BuildingSearchService {
+    private final HospitalInternalService hospitalInternalService;
+    private final BuildingService buildingService;
+
+    public List<BuildingInfoResponse> getBuildingsByHospitalId(Long hospitalId) {
+
+        // hospitalInternalService에서 hospitalId에 해당하는 tenantId 조회
+        Long tenantId = hospitalInternalService.getTenantIdByHospitalId(hospitalId);
+
+        // tenantId를 기반으로 건물 리스트 조회 후 반환
+        return buildingService.getBuildingsByTenantId(tenantId);
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingService.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingService.java
@@ -1,0 +1,8 @@
+package com.doubleo.hospitalservice.domain.building.service;
+
+import com.doubleo.hospitalservice.domain.building.dto.response.BuildingInfoResponse;
+import java.util.List;
+
+public interface BuildingService {
+    List<BuildingInfoResponse> getBuildingsByTenantId(Long tenantId);
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingServiceImpl.java
@@ -1,0 +1,31 @@
+package com.doubleo.hospitalservice.domain.building.service;
+
+import com.doubleo.hospitalservice.domain.building.domain.Building;
+import com.doubleo.hospitalservice.domain.building.dto.response.BuildingInfoResponse;
+import com.doubleo.hospitalservice.domain.building.repository.BuildingRepository;
+import com.doubleo.hospitalservice.global.exception.CommonException;
+import com.doubleo.hospitalservice.global.exception.errorcode.BuildingErrorCode;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BuildingServiceImpl implements BuildingService {
+
+    private final BuildingRepository buildingRepository;
+
+    // tenantId를 기반으로 소속 건물 리스트 조회
+    @Override
+    public List<BuildingInfoResponse> getBuildingsByTenantId(Long tenantId) {
+        List<Building> buildings = buildingRepository.findAllByTenantId(tenantId);
+
+        if (buildings.isEmpty()) {
+            throw new CommonException(BuildingErrorCode.BUILDING_LIST_EMPTY);
+        }
+
+        return buildings.stream().map(BuildingInfoResponse::from).toList();
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/building/service/BuildingServiceImpl.java
@@ -3,8 +3,6 @@ package com.doubleo.hospitalservice.domain.building.service;
 import com.doubleo.hospitalservice.domain.building.domain.Building;
 import com.doubleo.hospitalservice.domain.building.dto.response.BuildingInfoResponse;
 import com.doubleo.hospitalservice.domain.building.repository.BuildingRepository;
-import com.doubleo.hospitalservice.global.exception.CommonException;
-import com.doubleo.hospitalservice.global.exception.errorcode.BuildingErrorCode;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +19,6 @@ public class BuildingServiceImpl implements BuildingService {
     @Override
     public List<BuildingInfoResponse> getBuildingsByTenantId(Long tenantId) {
         List<Building> buildings = buildingRepository.findAllByTenantId(tenantId);
-
-        if (buildings.isEmpty()) {
-            throw new CommonException(BuildingErrorCode.BUILDING_LIST_EMPTY);
-        }
 
         return buildings.stream().map(BuildingInfoResponse::from).toList();
     }

--- a/src/main/java/com/doubleo/hospitalservice/domain/hospital/controller/HospitalController.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/hospital/controller/HospitalController.java
@@ -6,7 +6,6 @@ import com.doubleo.hospitalservice.domain.hospital.service.HospitalService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,16 +20,13 @@ public class HospitalController {
 
     @GetMapping
     @Operation(summary = "All Hospitals get API", description = "모든 병원을 조회하기 위한 API")
-    public ResponseEntity<List<HospitalInfoListResponse>> hospitalListGetAll() {
-        List<HospitalInfoListResponse> hospitals = hospitalService.getAllHospitals();
-        return ResponseEntity.ok(hospitals);
+    public List<HospitalInfoListResponse> hospitalListGetAll() {
+        return hospitalService.getAllHospitals();
     }
 
     @GetMapping(path = "/{hospitalId}")
     @Operation(summary = "Hospital Detail get API", description = "병원 상세 정보를 조회하기 위한 API")
-    public ResponseEntity<HospitalDetailInfoResponse> hospitalDetailGet(
-            @PathVariable Long hospitalId) {
-        HospitalDetailInfoResponse hospital = hospitalService.getHospitalById(hospitalId);
-        return ResponseEntity.ok(hospital);
+    public HospitalDetailInfoResponse hospitalDetailGet(@PathVariable Long hospitalId) {
+        return hospitalService.getHospitalById(hospitalId);
     }
 }

--- a/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalService.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalService.java
@@ -1,0 +1,6 @@
+package com.doubleo.hospitalservice.domain.hospital.service;
+
+// 병원 내부 서비스
+public interface HospitalInternalService {
+    Long getTenantIdByHospitalId(Long hospitalId);
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalServiceImpl.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalServiceImpl.java
@@ -1,6 +1,5 @@
 package com.doubleo.hospitalservice.domain.hospital.service;
 
-import com.doubleo.hospitalservice.domain.hospital.domain.Hospital;
 import com.doubleo.hospitalservice.domain.hospital.repository.HospitalRepository;
 import com.doubleo.hospitalservice.global.exception.CommonException;
 import com.doubleo.hospitalservice.global.exception.errorcode.HospitalErrorCode;
@@ -17,11 +16,9 @@ public class HospitalInternalServiceImpl implements HospitalInternalService {
     @Override
     public Long getTenantIdByHospitalId(Long hospitalId) {
         // 병원 아이디 -> tenant 아이디 조회
-        Hospital hospital =
-                hospitalRepository
-                        .findById(hospitalId)
-                        .orElseThrow(
-                                () -> new CommonException(HospitalErrorCode.HOSPITAL_NOT_FOUND));
-        return hospital.getTenantId();
+        return hospitalRepository
+                .findById(hospitalId)
+                .orElseThrow(() -> new CommonException(HospitalErrorCode.HOSPITAL_NOT_FOUND))
+                .getTenantId();
     }
 }

--- a/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalServiceImpl.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalInternalServiceImpl.java
@@ -1,0 +1,27 @@
+package com.doubleo.hospitalservice.domain.hospital.service;
+
+import com.doubleo.hospitalservice.domain.hospital.domain.Hospital;
+import com.doubleo.hospitalservice.domain.hospital.repository.HospitalRepository;
+import com.doubleo.hospitalservice.global.exception.CommonException;
+import com.doubleo.hospitalservice.global.exception.errorcode.HospitalErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 병원 내부 서비스 구현체
+@Service
+@RequiredArgsConstructor
+public class HospitalInternalServiceImpl implements HospitalInternalService {
+
+    private final HospitalRepository hospitalRepository;
+
+    @Override
+    public Long getTenantIdByHospitalId(Long hospitalId) {
+        // 병원 아이디 -> tenant 아이디 조회
+        Hospital hospital =
+                hospitalRepository
+                        .findById(hospitalId)
+                        .orElseThrow(
+                                () -> new CommonException(HospitalErrorCode.HOSPITAL_NOT_FOUND));
+        return hospital.getTenantId();
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalServiceImpl.java
+++ b/src/main/java/com/doubleo/hospitalservice/domain/hospital/service/HospitalServiceImpl.java
@@ -17,14 +17,8 @@ public class HospitalServiceImpl implements HospitalService {
     private final HospitalRepository hospitalRepository;
 
     public List<HospitalInfoListResponse> getAllHospitals() {
-        List<HospitalInfoListResponse> hospitalList =
-                hospitalRepository.findAll().stream().map(HospitalInfoListResponse::from).toList();
 
-        if (hospitalList.isEmpty()) {
-            throw new CommonException(HospitalErrorCode.HOSPITAL_LIST_EMPTY);
-        }
-
-        return hospitalList;
+        return hospitalRepository.findAll().stream().map(HospitalInfoListResponse::from).toList();
     }
 
     public HospitalDetailInfoResponse getHospitalById(Long id) {

--- a/src/main/java/com/doubleo/hospitalservice/global/exception/errorcode/BuildingErrorCode.java
+++ b/src/main/java/com/doubleo/hospitalservice/global/exception/errorcode/BuildingErrorCode.java
@@ -1,0 +1,20 @@
+package com.doubleo.hospitalservice.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BuildingErrorCode implements BaseErrorCode {
+    BUILDING_LIST_EMPTY(HttpStatus.BAD_REQUEST, "해당 병원의 건물이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/doubleo/hospitalservice/global/exception/errorcode/HospitalErrorCode.java
+++ b/src/main/java/com/doubleo/hospitalservice/global/exception/errorcode/HospitalErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum HospitalErrorCode implements BaseErrorCode {
-    HOSPITAL_LIST_EMPTY(HttpStatus.BAD_REQUEST, "해당 병원을 찾을 수 없습니다."),
     HOSPITAL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 병원을 찾을 수 없습니다"),
     ;
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,21 @@
+-- ==========================
+-- HOSPITAL 테이블 더미 데이터
+-- ==========================
+INSERT INTO hospital (tenant_id, hospital_name, hospital_policy)
+VALUES
+    (101, '서울대학교병원', 1),
+    (102, '삼성서울병원', 2),
+    (103, '연세세브란스병원', 1);
+
+
+-- ==========================
+-- BUILDING 테이블 더미 데이터
+-- ==========================
+INSERT INTO building (tenant_id, building_name, building_code)
+VALUES
+    (101, '서울대학교병원 본관', 'SNUH_MAIN'),
+    (101, '서울대학교병원 어린이병원', 'SNUH_CHILD'),
+    (102, '삼성서울병원 본관', 'SSUH_MAIN'),
+    (102, '삼성서울병원 암센터', 'SSUH_CANCER'),
+    (103, '연세세브란스병원 본관', 'YONSEI_MAIN'),
+    (103, '연세세브란스병원 심장혈관센터', 'YONSEI_HEART');

--- a/src/test/java/com/doubleo/hospitalservice/HospitalServiceApplicationTests.java
+++ b/src/test/java/com/doubleo/hospitalservice/HospitalServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.doubleo.hospitalservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(properties = {"spring.sql.init.mode=never"})
 class HospitalServiceApplicationTests {
 
     @Test


### PR DESCRIPTION
## 🔷 Jira Ticket ID

[KW-187] 건물 조회 기능 구현

---
## 📌 작업 내용 및 특이사항

- hospital id를 통해 tenant id를 조회로직을 hospitalInternalService에 분리하여 작성
- BuildingSearchService는 병원 아이디로 건물을 조회하는 서비스임
- BuildingSearchService는 단일 도메인 로직이 아닌 Hospital + Building 도메인이 사용되므로 별도의 SearchService로 분리함

---
## 📚 참고사항

- 테스트 실행 시 data.sql의 자동 실행을 비활성화하여 H2 데이터베이스에서 테이블 누락으로 인한 SQL 초기화 오류를 방지했습니다.


[KW-187]: https://teamdoubleo.atlassian.net/browse/KW-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ